### PR TITLE
feat: 네이버 API를 통한 책 검색

### DIFF
--- a/src/main/java/com/birdbook/birdbook/controller/book/BookController.java
+++ b/src/main/java/com/birdbook/birdbook/controller/book/BookController.java
@@ -1,0 +1,24 @@
+package com.birdbook.birdbook.controller.book;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.birdbook.birdbook.dto.book.reponse.BookRes;
+import com.birdbook.birdbook.service.book.BookService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/books")
+public class BookController {
+
+	private final BookService bookService;
+
+	@GetMapping("/{keyword}")
+	public BookRes searchBooks(@PathVariable("keyword") String keyword) {
+		return bookService.searchBook(keyword);
+	}
+}

--- a/src/main/java/com/birdbook/birdbook/dto/book/reponse/BookRes.java
+++ b/src/main/java/com/birdbook/birdbook/dto/book/reponse/BookRes.java
@@ -1,0 +1,18 @@
+package com.birdbook.birdbook.dto.book.reponse;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class BookRes {
+	private Item[] items;
+
+	@Getter
+	@NoArgsConstructor
+	static class Item {
+		private String title;
+		private String author;
+		private String isbn;
+	}
+}

--- a/src/main/java/com/birdbook/birdbook/dto/kakao/response/KakaoUserRes.java
+++ b/src/main/java/com/birdbook/birdbook/dto/kakao/response/KakaoUserRes.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-
 public class KakaoUserRes {
 	private String username;
 	private String role;

--- a/src/main/java/com/birdbook/birdbook/service/book/BookService.java
+++ b/src/main/java/com/birdbook/birdbook/service/book/BookService.java
@@ -1,0 +1,39 @@
+package com.birdbook.birdbook.service.book;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import com.birdbook.birdbook.dto.book.reponse.BookRes;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class BookService {
+
+	private final RestTemplate restTemplate;
+	private final String NAVER_BOOK_SEARCH_URL = "https://openapi.naver.com/v1/search/book.json?query={keyword}";
+	@Value("${naver.client-id}")
+	private String clientId;
+	@Value("${naver.client-secret}")
+	private String clientSecret;
+
+	public BookRes searchBook(String keyword) {
+		HttpHeaders headers = new HttpHeaders();
+
+		headers.add("X-Naver-Client-Id", clientId);
+		headers.add("X-Naver-Client-Secret", clientSecret);
+
+		HttpEntity<String> naverBookSearchRequest = new HttpEntity<>(headers);
+
+		BookRes bookRes = restTemplate.exchange(NAVER_BOOK_SEARCH_URL, HttpMethod.GET,
+			naverBookSearchRequest, BookRes.class, keyword).getBody();
+		return bookRes;
+	}
+}

--- a/src/main/resources/application-template.yml
+++ b/src/main/resources/application-template.yml
@@ -23,8 +23,8 @@ spring:
       client:
         registration:
           kakao:
-            client-id: ${CLIENT_ID}
-            redirect-uri:  ${REDIRECT_URI}
+            client-id: ${KAKAO_CLIENT_ID}
+            redirect-uri:  ${KAKAO_REDIRECT_URI}
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
             client-name: Kakao
@@ -36,3 +36,7 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+
+naver:
+  client-id: ${NAVER_CLIENT_ID}
+  client-secret: ${NAVER_CLIENT_SECRET}


### PR DESCRIPTION
## 📌 Related Issue
Closed #7 
## 🚀 Description
**`RestTemplate`을 통한 네이버 API와 연결**
* `REST API` 호출 방법 중, 가장 간단하게 구현이 가능할 것 같고 + 비동기 처리가 크게 필요없을 것 같다는 이유로 `RestTemplate`를 사용했습니다.
* `keyword`를 파라미터로 받아서 원하는 값을 넘겨주면 해당 `keyword`를 가진 도서 정보`(제목, 저자, isbn)`을 10개씩 반환합니다.

![image](https://github.com/user-attachments/assets/bb80cba4-8cea-488f-ad8a-53c662b2ecd6)
![image](https://github.com/user-attachments/assets/a2a706bb-a041-4d59-be44-34311c528169)
![image](https://github.com/user-attachments/assets/a0fab03b-9790-4dd9-9705-1af0c5865523)
## 📢 Comment
[네이버 책 검색 API 응답](https://developers.naver.com/docs/serviceapi/search/book/book.md#%EC%9D%91%EB%8B%B5)을 보니 `JSON 형식의 결괏값에서는 items 속성의 JSON 배열로 개별 검색 결과를 반환합니다.` 라고 나와있었습니다. 
따라서, `BookRes` dto 안에 **Item 클래스** 배열을 받고, **Item 클래스**를 **내부 클래스**로 구현하여 `제목, 저자, isbn` 값을 넣어주었습니다.