### PR TITLE
feat: 원하는 도서 저장 API 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,5 @@ out/
 application.yml
 docker-compose.yml
 mysql_data
+postgresql_data
 .env

--- a/build.gradle
+++ b/build.gradle
@@ -29,11 +29,13 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // PostgreSQL
+    runtimeOnly 'org.postgresql:postgresql'
 
     // Jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'

--- a/build.gradle
+++ b/build.gradle
@@ -35,13 +35,17 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    // jwt
+    // Jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+    // GraphQL
+    implementation 'org.springframework.boot:spring-boot-starter-graphql'
+    implementation 'com.graphql-java-kickstart:playground-spring-boot-starter:5.10.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/birdbook/birdbook/config/SecurityConfig.java
+++ b/src/main/java/com/birdbook/birdbook/config/SecurityConfig.java
@@ -54,9 +54,9 @@ public class SecurityConfig {
 					"/login",
 					"/login/oauth2/**",  // 카카오 로그인 경로 허용
 					"/api/auth/**", // 인증 관련 API 허용
-					"/graphiql/**", // graphql local에서 확인
-					"/graphql"
+					"/graphiql/**" // graphql local에서 확인
 				).permitAll()
+				.requestMatchers("/graphql").authenticated()
 				.anyRequest().authenticated());
 
 		// session : stateless

--- a/src/main/java/com/birdbook/birdbook/config/SecurityConfig.java
+++ b/src/main/java/com/birdbook/birdbook/config/SecurityConfig.java
@@ -53,7 +53,9 @@ public class SecurityConfig {
 					"/webjars/**",
 					"/login",
 					"/login/oauth2/**",  // 카카오 로그인 경로 허용
-					"/api/auth/**"       // 인증 관련 API 허용
+					"/api/auth/**", // 인증 관련 API 허용
+					"/graphiql/**", // graphql local에서 확인
+					"/graphql"
 				).permitAll()
 				.anyRequest().authenticated());
 

--- a/src/main/java/com/birdbook/birdbook/controller/book/BookController.java
+++ b/src/main/java/com/birdbook/birdbook/controller/book/BookController.java
@@ -2,6 +2,7 @@ package com.birdbook.birdbook.controller.book;
 
 import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.MutationMapping;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.birdbook.birdbook.domain.book.Book;
 import com.birdbook.birdbook.dto.book.reponse.BookSearchRes;
 import com.birdbook.birdbook.dto.book.request.BookReq;
+import com.birdbook.birdbook.dto.oauth.reponse.CustomUserDetails;
 import com.birdbook.birdbook.service.book.BookService;
 
 import lombok.RequiredArgsConstructor;
@@ -27,7 +29,7 @@ public class BookController {
 	}
 
 	@MutationMapping
-	public Book saveBook(@Argument BookReq input) {
+	public Book saveBook(@Argument BookReq input, @AuthenticationPrincipal CustomUserDetails userDetails) {
 		return bookService.saveBook(input);
 	}
 }

--- a/src/main/java/com/birdbook/birdbook/controller/book/BookController.java
+++ b/src/main/java/com/birdbook/birdbook/controller/book/BookController.java
@@ -1,11 +1,15 @@
 package com.birdbook.birdbook.controller.book;
 
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.MutationMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.birdbook.birdbook.dto.book.reponse.BookRes;
+import com.birdbook.birdbook.domain.book.Book;
+import com.birdbook.birdbook.dto.book.reponse.BookSearchRes;
+import com.birdbook.birdbook.dto.book.request.BookReq;
 import com.birdbook.birdbook.service.book.BookService;
 
 import lombok.RequiredArgsConstructor;
@@ -18,7 +22,12 @@ public class BookController {
 	private final BookService bookService;
 
 	@GetMapping("/{keyword}")
-	public BookRes searchBooks(@PathVariable("keyword") String keyword) {
+	public BookSearchRes searchBooks(@PathVariable("keyword") String keyword) {
 		return bookService.searchBook(keyword);
+	}
+
+	@MutationMapping
+	public Book saveBook(@Argument BookReq input) {
+		return bookService.saveBook(input);
 	}
 }

--- a/src/main/java/com/birdbook/birdbook/domain/book/Book.java
+++ b/src/main/java/com/birdbook/birdbook/domain/book/Book.java
@@ -1,11 +1,14 @@
 package com.birdbook.birdbook.domain.book;
 
+import com.birdbook.birdbook.domain.user.User;
 import com.birdbook.birdbook.dto.book.request.BookReq;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,11 +29,16 @@ public class Book {
 	private String author;
 	private String isbn;
 
-	public static Book from(BookReq req) {
+	@ManyToOne
+	@JoinColumn(name = "USER_ID")
+	private User user;
+
+	public static Book of(BookReq req, User user) {
 		return Book.builder()
 			.title(req.getTitle())
 			.author(req.getAuthor())
 			.isbn(req.getIsbn())
+			.user(user)
 			.build();
 	}
 }

--- a/src/main/java/com/birdbook/birdbook/domain/book/Book.java
+++ b/src/main/java/com/birdbook/birdbook/domain/book/Book.java
@@ -1,0 +1,26 @@
+package com.birdbook.birdbook.domain.book;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class Book {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	private String title;
+	private String author;
+	private String isbn;
+}

--- a/src/main/java/com/birdbook/birdbook/domain/book/Book.java
+++ b/src/main/java/com/birdbook/birdbook/domain/book/Book.java
@@ -1,5 +1,7 @@
 package com.birdbook.birdbook.domain.book;
 
+import com.birdbook.birdbook.dto.book.request.BookReq;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -23,4 +25,12 @@ public class Book {
 	private String title;
 	private String author;
 	private String isbn;
+
+	public static Book from(BookReq req) {
+		return Book.builder()
+			.title(req.getTitle())
+			.author(req.getAuthor())
+			.isbn(req.getIsbn())
+			.build();
+	}
 }

--- a/src/main/java/com/birdbook/birdbook/domain/user/User.java
+++ b/src/main/java/com/birdbook/birdbook/domain/user/User.java
@@ -1,5 +1,6 @@
 package com.birdbook.birdbook.domain.user;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -21,6 +22,7 @@ public class User {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "USER_ID")
 	private Long id;
 	private String username;
 	private String role;

--- a/src/main/java/com/birdbook/birdbook/dto/book/reponse/BookSearchRes.java
+++ b/src/main/java/com/birdbook/birdbook/dto/book/reponse/BookSearchRes.java
@@ -5,7 +5,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class BookRes {
+public class BookSearchRes {
 	private Item[] items;
 
 	@Getter

--- a/src/main/java/com/birdbook/birdbook/dto/book/request/BookReq.java
+++ b/src/main/java/com/birdbook/birdbook/dto/book/request/BookReq.java
@@ -9,4 +9,5 @@ public class BookReq {
 	private String title;
 	private String author;
 	private String isbn;
+	private Long userId;
 }

--- a/src/main/java/com/birdbook/birdbook/dto/book/request/BookReq.java
+++ b/src/main/java/com/birdbook/birdbook/dto/book/request/BookReq.java
@@ -1,0 +1,12 @@
+package com.birdbook.birdbook.dto.book.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BookReq {
+	private String title;
+	private String author;
+	private String isbn;
+}

--- a/src/main/java/com/birdbook/birdbook/repository/book/BookRepository.java
+++ b/src/main/java/com/birdbook/birdbook/repository/book/BookRepository.java
@@ -1,0 +1,8 @@
+package com.birdbook.birdbook.repository.book;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.birdbook.birdbook.domain.book.Book;
+
+public interface BookRepository extends JpaRepository<Book, Long> {
+}

--- a/src/main/java/com/birdbook/birdbook/service/book/BookService.java
+++ b/src/main/java/com/birdbook/birdbook/service/book/BookService.java
@@ -5,9 +5,13 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
-import com.birdbook.birdbook.dto.book.reponse.BookRes;
+import com.birdbook.birdbook.domain.book.Book;
+import com.birdbook.birdbook.dto.book.reponse.BookSearchRes;
+import com.birdbook.birdbook.dto.book.request.BookReq;
+import com.birdbook.birdbook.repository.book.BookRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,12 +23,13 @@ public class BookService {
 
 	private final RestTemplate restTemplate;
 	private final String NAVER_BOOK_SEARCH_URL = "https://openapi.naver.com/v1/search/book.json?query={keyword}";
+	private final BookRepository bookRepository;
 	@Value("${naver.client-id}")
 	private String clientId;
 	@Value("${naver.client-secret}")
 	private String clientSecret;
 
-	public BookRes searchBook(String keyword) {
+	public BookSearchRes searchBook(String keyword) {
 		HttpHeaders headers = new HttpHeaders();
 
 		headers.add("X-Naver-Client-Id", clientId);
@@ -32,8 +37,15 @@ public class BookService {
 
 		HttpEntity<String> naverBookSearchRequest = new HttpEntity<>(headers);
 
-		BookRes bookRes = restTemplate.exchange(NAVER_BOOK_SEARCH_URL, HttpMethod.GET,
-			naverBookSearchRequest, BookRes.class, keyword).getBody();
-		return bookRes;
+		BookSearchRes bookSearchRes = restTemplate.exchange(NAVER_BOOK_SEARCH_URL, HttpMethod.GET,
+			naverBookSearchRequest, BookSearchRes.class, keyword).getBody();
+		return bookSearchRes;
+	}
+
+	@Transactional
+	public Book saveBook(BookReq req) {
+		Book book = Book.from(req);
+		bookRepository.save(book);
+		return book;
 	}
 }

--- a/src/main/java/com/birdbook/birdbook/service/book/BookService.java
+++ b/src/main/java/com/birdbook/birdbook/service/book/BookService.java
@@ -9,9 +9,11 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
 import com.birdbook.birdbook.domain.book.Book;
+import com.birdbook.birdbook.domain.user.User;
 import com.birdbook.birdbook.dto.book.reponse.BookSearchRes;
 import com.birdbook.birdbook.dto.book.request.BookReq;
 import com.birdbook.birdbook.repository.book.BookRepository;
+import com.birdbook.birdbook.repository.user.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +26,7 @@ public class BookService {
 	private final RestTemplate restTemplate;
 	private final String NAVER_BOOK_SEARCH_URL = "https://openapi.naver.com/v1/search/book.json?query={keyword}";
 	private final BookRepository bookRepository;
+	private final UserRepository userRepository;
 	@Value("${naver.client-id}")
 	private String clientId;
 	@Value("${naver.client-secret}")
@@ -44,7 +47,9 @@ public class BookService {
 
 	@Transactional
 	public Book saveBook(BookReq req) {
-		Book book = Book.from(req);
+		User user = userRepository.findById(req.getUserId())
+			.orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다."));
+		Book book = Book.of(req, user);
 		bookRepository.save(book);
 		return book;
 	}

--- a/src/main/resources/application-template.yml
+++ b/src/main/resources/application-template.yml
@@ -18,6 +18,12 @@ spring:
         format_sql: true
     open-in-view: false
 
+  graphql:
+    graphiql:
+      enabled: true # graphiql을 통해 테스트 가능 여부 (localhost:8080/graphiql)
+      printer:
+        enabled: true # show-sql와 같이 graphql 콘솔에 쿼리 출력
+
   security:
     oauth2:
       client:

--- a/src/main/resources/application-template.yml
+++ b/src/main/resources/application-template.yml
@@ -6,14 +6,14 @@ spring:
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    driver-class-name: org.postgresql.Driver
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MySQLDialect
+        dialect: org.hibernate.dialect.PostgreSQLDialect
         show_sql: true
         format_sql: true
     open-in-view: false

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -1,0 +1,25 @@
+type Book {
+    id: ID!
+    title: String!
+    author: String!
+    isbn: String!
+}
+
+# input type
+input BookReq {
+    title: String!
+    author: String!
+    isbn: String!
+}
+
+# save
+type Mutation {
+    saveBook(input: BookReq!): Book!
+}
+
+# Query가 꼭 포함되어야 함
+type Query {
+    # 기본적인 책 조회를 위한 쿼리 추가
+    getBooks: [Book!]! # 모든 책을 조회하는 쿼리
+    getBook(id: ID!): Book # ID로 특정 책을 조회하는 쿼리
+}

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -10,6 +10,7 @@ input BookReq {
     title: String!
     author: String!
     isbn: String!
+    userId: Int!
 }
 
 # save


### PR DESCRIPTION
## 📌 Related Issue
Closed #9 
## 🚀 Description
**`GraphQL` 스키마 작성**
```graphql
type Book {
    id: ID!
    title: String!
    author: String!
    isbn: String!
}

# input type
input BookReq {
    title: String!
    author: String!
    isbn: String!
    userId: Int!
}

# save
type Mutation {
    saveBook(input: BookReq!): Book!
}
```
* 도서 저장 API를 위해 `Mutation` 스키마를 작성했습니다.
* 여러 인자보다 하나의 인자를 넘겨주는 것이 확장성 측면에서 좋다고 판단하여 `BookReq`를 선언하여 넘겨주었습니다.
* `localhost:{포트 번호}/graphiql` 로 접속하여 API 테스트가 가능합니다.

**User : Book = 1 : N 단방향 관계 설정**
* 사용자는 검색 한 도서 중 원하는 도서를 저장할 수 있다는 요구사항이 있어서 `User`와 `Book`을 연결해주어야 했습니다.
* 현재 `Book`에서 `User 객체`를 가져올 일이 없기 때문에 단방향 매핑을 해주었습니다.
## 📢 Comment
✅ 요구사항에 DB를 `PostgreSQL`로 사용하라고 명시되어 있어서 `MySQL -> PostgreSQL`로 변경했습니다.
✅ [GraphQL 스키마는 기본적으로 ‘Query’ 타입을 필요로 합니다. 이는 GraphQL API를 사용할 때 데이터를 조회하는 기본적인 방법이기 때문](https://www.inflearn.com/community/questions/1093368/query-%EC%97%86%EC%9D%B4-mutation-%EB%A7%8C%EC%9E%91%EC%84%B1%ED%95%98%EB%A9%B4-%EC%98%A4%EB%A5%98%EA%B0%80-%EB%82%9C%EB%8B%A4?srsltid=AfmBOorklt8rDZgrvctabW4bN7meedpzwq_5qgidW41ctLgN06fsQb3Y)라는 글을 보고
```graphql
# Query가 꼭 포함되어야 함
type Query {
    # 기본적인 책 조회를 위한 쿼리 추가
    getBooks: [Book!]! # 모든 책을 조회하는 쿼리
    getBook(id: ID!): Book # ID로 특정 책을 조회하는 쿼리
}
```
`Query 스키마`도 함께 작성하였습니다.