### PR TITLE
feat: 노트 삭제 API

### DIFF
--- a/src/main/java/com/birdbook/birdbook/controller/note/NoteController.java
+++ b/src/main/java/com/birdbook/birdbook/controller/note/NoteController.java
@@ -6,6 +6,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.birdbook.birdbook.domain.note.Note;
+import com.birdbook.birdbook.dto.note.request.NoteDeleteReq;
 import com.birdbook.birdbook.dto.note.request.NoteReq;
 import com.birdbook.birdbook.dto.oauth.reponse.CustomUserDetails;
 import com.birdbook.birdbook.service.note.NoteService;
@@ -21,5 +22,10 @@ public class NoteController {
 	@MutationMapping
 	public Note saveNote(@Argument NoteReq input, @AuthenticationPrincipal CustomUserDetails userDetails) {
 		return noteService.saveNote(input);
+	}
+
+	@MutationMapping
+	public Long deleteNote(@Argument NoteDeleteReq input, @AuthenticationPrincipal CustomUserDetails userDetails) {
+		return noteService.deleteNote(input);
 	}
 }

--- a/src/main/java/com/birdbook/birdbook/domain/note/Note.java
+++ b/src/main/java/com/birdbook/birdbook/domain/note/Note.java
@@ -30,6 +30,7 @@ public class Note extends BaseEntity {
 	private Long id;
 	private String title;
 	private String content;
+	private boolean isDeleted = false;
 
 	@ManyToOne
 	@JoinColumn(name = "BOOK_ID")
@@ -41,5 +42,9 @@ public class Note extends BaseEntity {
 			.content(req.getContent())
 			.book(book).
 			build();
+	}
+
+	public void deleteNote() {
+		this.isDeleted = true;
 	}
 }

--- a/src/main/java/com/birdbook/birdbook/dto/note/request/NoteDeleteReq.java
+++ b/src/main/java/com/birdbook/birdbook/dto/note/request/NoteDeleteReq.java
@@ -1,0 +1,10 @@
+package com.birdbook.birdbook.dto.note.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NoteDeleteReq {
+	private Long noteId;
+}

--- a/src/main/java/com/birdbook/birdbook/service/note/NoteService.java
+++ b/src/main/java/com/birdbook/birdbook/service/note/NoteService.java
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.birdbook.birdbook.domain.book.Book;
 import com.birdbook.birdbook.domain.note.Note;
+import com.birdbook.birdbook.dto.note.request.NoteDeleteReq;
 import com.birdbook.birdbook.dto.note.request.NoteReq;
 import com.birdbook.birdbook.repository.book.BookRepository;
 import com.birdbook.birdbook.repository.note.NoteRepository;
@@ -23,9 +24,19 @@ public class NoteService {
 	public Note saveNote(NoteReq req) {
 		Book book = bookRepository.findById(req.getBookId())
 			.orElseThrow(() -> new IllegalArgumentException("도서가 존재하지 않습니다."));
-
 		Note note = Note.of(req, book);
 		noteRepository.save(note);
 		return note;
+	}
+
+	@Transactional
+	public Long deleteNote(NoteDeleteReq req) {
+		Note note = noteRepository.findById(req.getNoteId())
+			.orElseThrow(() -> new IllegalArgumentException("작성한 노트가 존재하지 않습니다."));
+		if (note.isDeleted()) {
+			throw new IllegalArgumentException("이미 삭제된 노트입니다.");
+		}
+		note.deleteNote();
+		return note.getId();
 	}
 }

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -21,7 +21,6 @@ type Note {
     id: ID!
     title: String!
     content: String!
-    createAt: String!
 }
 
 # input type
@@ -43,11 +42,16 @@ input NoteReq {
     content: String!
 }
 
-# save
+input NoteDeleteReq {
+    noteId: Int!
+}
+
+# save / delete
 type Mutation {
     saveBook(input: BookReq!): Book!
     saveBookLike(input: BookLikeReq!): BookLike!
     saveNote(input: NoteReq!): Note!
+    deleteNote(input: NoteDeleteReq!): Int! # 삭제된 노트의 id 값 반환 -> 서브셋 요청 불가
 }
 
 # Query가 꼭 포함되어야 함


### PR DESCRIPTION
## 📌 Related Issue
Closed #15 
## 🚀 Description
**`GraphQL `스키마 작성**
```graphql
type Mutation {
    deleteNote(input: NoteDeleteReq!): Int!
}
```
* **Int 타입**으로 반환 타입을 설정해 주어서 api 요청 시 **서브셋** `(GraphQL에서 특정 필드의 하위 필드를 요청하는 것. 복잡한 객체를 요청할 때, 그 객체의 특정 속성들만 선택적으로 요청할 수 있다.) `을 요청할 수는 없습니다.

![image](https://github.com/user-attachments/assets/ca910c21-5f43-4399-a02c-fa1f468d9d63)
위와 같이 삭제된 노트의 id값이 반환됩니다.
## 📢 Comment
* 노트 삭제를 `soft delete`로 구현하기 위해 `isDelete` 필드를 생성했습니다.